### PR TITLE
fix: Use correct binary path

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,11 +1,12 @@
 use std::env;
+use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
     println!("cargo:rustc-link-search=native=C:\\Program Files\\Npcap\\Lib\\x64");
     tauri_build::build();
     if env::consts::OS == "linux" && env::var("CARGO_FEATURE_SETCAP").is_ok() {
-        let binary_path = "src-tauri/target/debug/mualani_guide";
+        let binary_path: PathBuf = ["target", &env::var("PROFILE").unwrap(), "mualani_guide"].iter().collect();
 
         let status = Command::new("sudo")
             .arg("setcap")


### PR DESCRIPTION
Also for multiple profiles by inspecting the `PROFILE` env var. 

Unfortunately, that is not enough to make it work because it appears the binary is re-written afterwards and the capabilities reset or something similar. Either way, I still need to manually run the command after the build has completed and then re-run `yarn tauri dev`.